### PR TITLE
Allow to specify multiple same keys

### DIFF
--- a/systemd/unit.jinja
+++ b/systemd/unit.jinja
@@ -1,6 +1,12 @@
 {% for section, sectioncontent in config.iteritems() -%}
 [{{ section }}]
 {% for key, value in sectioncontent.iteritems() -%}
+{%- if value is list %}
+  {%- for subvalue in value %}
+{{ key }}={{ subvalue }}
+  {%- endfor %}
+{%- else %}
 {{ key }}={{ value }}
+{%- endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
systemd unit files can contain multiple identical keys. For example file `/usr/lib/systemd/system/accounts-daemon.service` (on my Fedora 25) contains:

```ini
[Service]
Type=dbus
BusName=org.freedesktop.Accounts
ExecStart=/usr/libexec/accounts-daemon
StandardOutput=syslog
Environment=GVFS_DISABLE_FUSE=1
Environment=GIO_USE_VFS=local
Environment=GVFS_REMOTE_VOLUME_MONITOR_IGNORE=1
```

So I want to have possibility to create unitfile like this.