### PR TITLE
Use correct path for custom-made unitfiles

### DIFF
--- a/systemd/units.sls
+++ b/systemd/units.sls
@@ -1,7 +1,7 @@
 {% for unittype, units in pillar['systemd'].iteritems()  %}
 {% for unit, unitconfig in units.iteritems() %}
 
-/lib/systemd/system/{{ unit }}.{{ unittype }}:
+/etc/systemd/system/{{ unit }}.{{ unittype }}:
   file.managed:
     - template: jinja
     - source: salt://systemd/unit.jinja


### PR DESCRIPTION
`/lib/systemd/system` is path for unitfiles deployed with system packages.

`/etc/systemd/system` is correct path for unitfiles deployed manually that does not belong to packages.