### PR TITLE
Use items() istead of iteritems()

### DIFF
--- a/systemd/units.sls
+++ b/systemd/units.sls
@@ -1,5 +1,5 @@
-{% for unittype, units in salt['pillar.get']('systemd', {}).iteritems()  %}
-{% for unit, unitconfig in units.iteritems() %}
+{% for unittype, units in salt['pillar.get']('systemd', {}).items()  %}
+{% for unit, unitconfig in units.items() %}
 
 /etc/systemd/system/{{ unit }}.{{ unittype }}:
   file.managed:


### PR DESCRIPTION
`iteritems()` is indeed recommended for Python 2 for performance reasons and it's the same as `items()` in Python 3.
But `items()` works in both, so unless you really need performance it's better to use `items()` in Salt formulas, so they will work then Salt will switch to Python 3 someday.